### PR TITLE
Use net.cgrand/seqexp for defn parsing

### DIFF
--- a/inspect-probe/project.clj
+++ b/inspect-probe/project.clj
@@ -8,7 +8,8 @@
                  [clj-kafka "0.3.4"]
                  [com.taoensso/nippy "2.11.0-beta1"]
                  [fipp "0.6.3"]
-                 [clj-time "0.11.0"]]
+                 [clj-time "0.11.0"]
+                 [net.cgrand/seqexp "0.3.0"]]
 
   :source-paths ["src/clj/"]
 


### PR DESCRIPTION
1. Preserves the original arities specified in defn forms.

2. Preserves metadata on argument vectors and non-destructured (symbol)
   arguments.

3. Produces tidy argument maps for sending off to Kafka.

4. Makes any results of argument vector destructuring available inside
   the defn body/bodies.